### PR TITLE
fix: remove sentence in instructions

### DIFF
--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -1517,7 +1517,7 @@ Right below the variable you just created, use echo to print it so you can see w
 
 ### 1200.1
 
-Run the script a few times, go to the rent menu, enter a bike that is available and one that isn't. You should have some `BMX` bikes that aren't available.
+Run the script a few times, go to the rent menu, enter a bike that is available and one that isn't.
 
 #### HINTS
 

--- a/tutorial.json
+++ b/tutorial.json
@@ -2685,7 +2685,7 @@
               "ad6701ab87f1bd840f0dc1fd1f5e12bb0e8b183d"
             ]
           },
-          "content": "Run the script a few times, go to the rent menu, enter a bike that is available and one that isn't. You should have some `BMX` bikes that aren't available.",
+          "content": "Run the script a few times, go to the rent menu, enter a bike that is available and one that isn't.",
           "hints": [
             "Enter `./bike-shop.sh` in the terminal and press enter",
             "Make sure you are in the `project` folder first"


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
In this pull request, I removed the sentence for "You should have some `BMX` bikes that aren't available." because they are currently unavailable. Our selection filter now only displays bikes with availability=true.