### PR TITLE
Improving .bashrc Trap Command for Bash Script

### DIFF
--- a/.freeCodeCamp/.bashrc
+++ b/.freeCodeCamp/.bashrc
@@ -130,4 +130,4 @@ export PATH="$PATH:$HOME/.rvm/bin"
 PS1='camper: \[\033[01;34m\]/${PWD##*/}\[\033[00m\]\$ '
 HISTFILE=/workspace/.bash_history
 PROMPT_COMMAND='echo $PWD >> /workspace/project/.freeCodeCamp/test/.cwd; history -a'
-trap 'echo $BASH_COMMAND >> /workspace/project/.freeCodeCamp/test/.next_command' DEBUG
+trap 'echo $BASH_COMMAND >> /workspace/project/.freeCodeCamp/test/.next_command; tail -n 100 /workspace/project/.freeCodeCamp/test/.next_command > /workspace/project/.freeCodeCamp/test/.next_command.tmp && mv /workspace/project/.freeCodeCamp/test/.next_command.tmp /workspace/project/.freeCodeCamp/test/.next_command' DEBUG


### PR DESCRIPTION
**Problem**

The .bashrc file contains the following line to append every executed command to a file:
[
`[trap 'echo $BASH_COMMAND >> /workspace/project/.freeCodeCamp/test/.next_command' DEBUG]`

**Issues Identified:**

==>File Size Growth: Appending all executed commands to the .next_command file without any limits may result in excessive file size over time.

==>Performance Impact: Continuously appending commands could lead to slower performance, especially in environments with frequent command execution.

**Proposed Solution**

Modify the trap command to limit the number of lines retained in the .next_command file. This ensures that the file does not grow indefinitely, mitigating performance issues and disk space usage.

```
trap 'echo $BASH_COMMAND >> /workspace/project/.freeCodeCamp/test/.next_command; \
      tail -n 100 /workspace/project/.freeCodeCamp/test/.next_command > /workspace/project/.freeCodeCamp/test/.next_command.tmp && \
      mv /workspace/project/.freeCodeCamp/test/.next_command.tmp /workspace/project/.freeCodeCamp/test/.next_command' DEBUG
```

